### PR TITLE
Add interdiction sphere range to ui.

### DIFF
--- a/lib/extensions/item_ui_extension.dart
+++ b/lib/extensions/item_ui_extension.dart
@@ -53,6 +53,7 @@ extension ItemUI on Item {
           EveEchoesAttribute.activationCost,
           EveEchoesAttribute.powerGridRequirement,
           EveEchoesAttribute.fuelNeed,
+          EveEchoesAttribute.warpDisruptDistance
         ];
 
       case 1040: // Combat Rigs

--- a/lib/model/ship/eve_echoes_attribute.dart
+++ b/lib/model/ship/eve_echoes_attribute.dart
@@ -221,6 +221,7 @@ enum EveEchoesAttribute {
   capacitorRechargeTimeAdjustment,
   enableCapacitorNeedAdjustment,
   warpJammerstrength,
+  warpDisruptDistance,
   scanResolutionAdjustment,
   rangeSkillBonus,
   accuracyFalloffAdjustment,
@@ -523,6 +524,8 @@ extension ShipAttributeExtenstion on EveEchoesAttribute {
         return 354;
       case EveEchoesAttribute.moduleSize:
         return 13;
+      case EveEchoesAttribute.warpDisruptDistance:
+        return 10010;
 
       case EveEchoesAttribute.moduleCanFitAttributeID:
         return 3000;


### PR DESCRIPTION
Added the attribute `warpDisruptDistance` (with id `10010`) to the ui attributes list.

Fixes sweet-org/sweet#3