### PR TITLE
Added blacklist for non-integratable rigs

### DIFF
--- a/lib/bloc/data_loading_bloc/data_loading_bloc.dart
+++ b/lib/bloc/data_loading_bloc/data_loading_bloc.dart
@@ -106,6 +106,8 @@ class DataLoadingBloc extends Bloc<DataLoadingBlocEvent, DataLoadingBlocState> {
       await _itemRepository.openDatabase();
       print('${DateTime.now()}: Processing market groups');
       await _itemRepository.processMarketGroups();
+      print('${DateTime.now()}: Processing non integratable rigs');
+      await _itemRepository.processExcludeFusionRigs();
       print('${DateTime.now()}: Loading language strings');
       await _localisationRepository.loadStringsForLanguage('en');
       print(

--- a/lib/pages/market_browser/market_browser.dart
+++ b/lib/pages/market_browser/market_browser.dart
@@ -56,12 +56,12 @@ typedef ItemCallback = void Function(Item item);
 
 class MarketGroupTile extends StatelessWidget {
   const MarketGroupTile(
-      {Key? key, required this.marketGroup, required this.onItemSelected, List<String>? blacklistCalCodes })
-      : blacklistCalCodes = blacklistCalCodes ?? const [], super(key: key);
+      {Key? key, required this.marketGroup, required this.onItemSelected, List<int>? blacklistItems })
+      : blacklistItems = blacklistItems ?? const [], super(key: key);
 
   final MarketGroup marketGroup;
   final ItemCallback onItemSelected;
-  final List<String> blacklistCalCodes;
+  final List<int> blacklistItems;
 
   @override
   Widget build(BuildContext context) {
@@ -73,7 +73,7 @@ class MarketGroupTile extends StatelessWidget {
       var sorted = items;
       sorted.sort((a, b) => a.id < b.id ? -1 : 1);
       children = sorted
-          .where((item) => !blacklistCalCodes.any((calCode) => item.mainCalCode?.startsWith(calCode) ?? false))
+          .where((item) => !blacklistItems.any((itemId) => item.id == itemId))
           .map((item) => ItemListTile(item: item, onSelected: onItemSelected))
           .toList();
     } else {
@@ -83,7 +83,7 @@ class MarketGroupTile extends StatelessWidget {
           .map((mg) => MarketGroupTile(
                 marketGroup: mg,
                 onItemSelected: onItemSelected,
-                blacklistCalCodes: blacklistCalCodes,
+                blacklistItems: blacklistItems,
               ))
           .toList();
     }

--- a/lib/pages/market_browser/market_browser.dart
+++ b/lib/pages/market_browser/market_browser.dart
@@ -56,11 +56,12 @@ typedef ItemCallback = void Function(Item item);
 
 class MarketGroupTile extends StatelessWidget {
   const MarketGroupTile(
-      {Key? key, required this.marketGroup, required this.onItemSelected})
-      : super(key: key);
+      {Key? key, required this.marketGroup, required this.onItemSelected, List<String>? blacklistCalCodes })
+      : blacklistCalCodes = blacklistCalCodes ?? const [], super(key: key);
 
   final MarketGroup marketGroup;
   final ItemCallback onItemSelected;
+  final List<String> blacklistCalCodes;
 
   @override
   Widget build(BuildContext context) {
@@ -72,6 +73,7 @@ class MarketGroupTile extends StatelessWidget {
       var sorted = items;
       sorted.sort((a, b) => a.id < b.id ? -1 : 1);
       children = sorted
+          .where((item) => !blacklistCalCodes.any((calCode) => item.mainCalCode?.startsWith(calCode) ?? false))
           .map((item) => ItemListTile(item: item, onSelected: onItemSelected))
           .toList();
     } else {
@@ -81,6 +83,7 @@ class MarketGroupTile extends StatelessWidget {
           .map((mg) => MarketGroupTile(
                 marketGroup: mg,
                 onItemSelected: onItemSelected,
+                blacklistCalCodes: blacklistCalCodes,
               ))
           .toList();
     }

--- a/lib/pages/ship_fitting/bloc/ship_fitting_bloc/bloc.dart
+++ b/lib/pages/ship_fitting/bloc/ship_fitting_bloc/bloc.dart
@@ -186,22 +186,17 @@ class ShipFittingBloc extends Bloc<ShipFittingEvent, ShipFittingState> {
         },
       ).toList();
     }
-    //ToDo: Replace hardcoded list to filter out "cannot be integrated" attributes
-    //The id of the attribute is 193
-    List<String> blacklist = [
-      // Higgs anchors
-      "/Fusion_Astronautic/Higgs_Anchor/"
-    ];
-    initialItems = initialItems.where((item) {
-      return !blacklist.any((calCode) => item.mainCalCode?.startsWith(calCode) ?? false);
-    }).toList();
+    // Filter out non integratable rigs
+    initialItems = initialItems.where(
+            (item) => !_itemRepository.excludeFusionRigs.any((itemId) => item.id == itemId)
+    ).toList();
     emit(OpenRigIntegratorDrawer(
       rigIntegrator: event.rigIntegrator,
       topGroup: filteredGroup,
       initialItems: initialItems,
       slotIndex: event.slotIndex,
       fitting: fitting,
-      blacklistCalCodes: blacklist
+      blacklistItems: _itemRepository.excludeFusionRigs
     ));
   }
 }

--- a/lib/pages/ship_fitting/bloc/ship_fitting_bloc/bloc.dart
+++ b/lib/pages/ship_fitting/bloc/ship_fitting_bloc/bloc.dart
@@ -186,13 +186,22 @@ class ShipFittingBloc extends Bloc<ShipFittingEvent, ShipFittingState> {
         },
       ).toList();
     }
-
+    //ToDo: Replace hardcoded list to filter out "cannot be integrated" attributes
+    //The id of the attribute is 193
+    List<String> blacklist = [
+      // Higgs anchors
+      "/Fusion_Astronautic/Higgs_Anchor/"
+    ];
+    initialItems = initialItems.where((item) {
+      return !blacklist.any((calCode) => item.mainCalCode?.startsWith(calCode) ?? false);
+    }).toList();
     emit(OpenRigIntegratorDrawer(
       rigIntegrator: event.rigIntegrator,
       topGroup: filteredGroup,
       initialItems: initialItems,
       slotIndex: event.slotIndex,
       fitting: fitting,
+      blacklistCalCodes: blacklist
     ));
   }
 }

--- a/lib/pages/ship_fitting/bloc/ship_fitting_bloc/states.dart
+++ b/lib/pages/ship_fitting/bloc/ship_fitting_bloc/states.dart
@@ -61,6 +61,7 @@ class OpenRigIntegratorDrawer extends ShipFittingState {
   final MarketGroup topGroup;
   final List<Item> initialItems;
   final int slotIndex;
+  final List<String> blacklistCalCodes;
 
   OpenRigIntegratorDrawer({
     required this.rigIntegrator,
@@ -68,6 +69,7 @@ class OpenRigIntegratorDrawer extends ShipFittingState {
     required this.initialItems,
     required this.slotIndex,
     required FittingSimulator fitting,
+    this.blacklistCalCodes = const []
   }) : super(fitting);
 
   @override

--- a/lib/pages/ship_fitting/bloc/ship_fitting_bloc/states.dart
+++ b/lib/pages/ship_fitting/bloc/ship_fitting_bloc/states.dart
@@ -61,7 +61,7 @@ class OpenRigIntegratorDrawer extends ShipFittingState {
   final MarketGroup topGroup;
   final List<Item> initialItems;
   final int slotIndex;
-  final List<String> blacklistCalCodes;
+  final List<int> blacklistItems;
 
   OpenRigIntegratorDrawer({
     required this.rigIntegrator,
@@ -69,7 +69,7 @@ class OpenRigIntegratorDrawer extends ShipFittingState {
     required this.initialItems,
     required this.slotIndex,
     required FittingSimulator fitting,
-    this.blacklistCalCodes = const []
+    this.blacklistItems = const []
   }) : super(fitting);
 
   @override

--- a/lib/pages/ship_fitting/widgets/ship_fitting_body.dart
+++ b/lib/pages/ship_fitting/widgets/ship_fitting_body.dart
@@ -69,7 +69,7 @@ class _ShipFittingBodyState extends State<ShipFittingBody>
         context,
         state.topGroup,
         state.initialItems,
-        state.blacklistCalCodes
+        state.blacklistItems
       );
 
       if (selectedItem != null) {
@@ -215,7 +215,7 @@ class _ShipFittingBodyState extends State<ShipFittingBody>
     BuildContext context,
     MarketGroup? topGroup,
     List<Item>? initialItems,
-    List<String>? blacklistCalCodes,
+    List<int>? blacklistItems,
   ) async {
     return await showModalBottomSheet<Item>(
       context: context,
@@ -223,7 +223,7 @@ class _ShipFittingBodyState extends State<ShipFittingBody>
       builder: (context) => ShipFittingContextDrawer(
         marketGroup: topGroup,
         initialFilteredItems: initialItems,
-        blacklistCalCodes: blacklistCalCodes,
+        blacklistItems: blacklistItems,
       ),
     );
   }

--- a/lib/pages/ship_fitting/widgets/ship_fitting_body.dart
+++ b/lib/pages/ship_fitting/widgets/ship_fitting_body.dart
@@ -55,6 +55,7 @@ class _ShipFittingBodyState extends State<ShipFittingBody>
         context,
         state.topGroup,
         state.initialItems,
+        null
       );
 
       await _handleDrawerSelection(
@@ -68,6 +69,7 @@ class _ShipFittingBodyState extends State<ShipFittingBody>
         context,
         state.topGroup,
         state.initialItems,
+        state.blacklistCalCodes
       );
 
       if (selectedItem != null) {
@@ -213,6 +215,7 @@ class _ShipFittingBodyState extends State<ShipFittingBody>
     BuildContext context,
     MarketGroup? topGroup,
     List<Item>? initialItems,
+    List<String>? blacklistCalCodes,
   ) async {
     return await showModalBottomSheet<Item>(
       context: context,
@@ -220,6 +223,7 @@ class _ShipFittingBodyState extends State<ShipFittingBody>
       builder: (context) => ShipFittingContextDrawer(
         marketGroup: topGroup,
         initialFilteredItems: initialItems,
+        blacklistCalCodes: blacklistCalCodes,
       ),
     );
   }

--- a/lib/pages/ship_fitting/widgets/ship_fitting_context_drawer.dart
+++ b/lib/pages/ship_fitting/widgets/ship_fitting_context_drawer.dart
@@ -11,17 +11,17 @@ import '../../../widgets/search_bar.dart';
 class ShipFittingContextDrawer extends StatefulWidget {
   final MarketGroup marketGroup;
   final List<Item> initialItems;
-  final List<String> blacklistCalCodes;
+  final List<int> blacklistItems;
 
   ShipFittingContextDrawer({
     Key? key,
     MarketGroup? marketGroup,
     List<Item>? initialFilteredItems,
-    List<String>? blacklistCalCodes,
+    List<int>? blacklistItems,
   })  : assert(marketGroup != null || initialFilteredItems != null),
         marketGroup = marketGroup ?? MarketGroup.invalid,
         initialItems = initialFilteredItems ?? [],
-        blacklistCalCodes = blacklistCalCodes ?? [],
+        blacklistItems = blacklistItems ?? List<int>.empty(),
         super(key: key);
 
   @override
@@ -111,7 +111,7 @@ class _ShipFittingContextDrawerState extends State<ShipFittingContextDrawer> {
         return MarketGroupTile(
           marketGroup: child,
           onItemSelected: (item) => Navigator.pop(context, item),
-          blacklistCalCodes: widget.blacklistCalCodes,
+          blacklistItems: widget.blacklistItems,
         );
       },
     );

--- a/lib/pages/ship_fitting/widgets/ship_fitting_context_drawer.dart
+++ b/lib/pages/ship_fitting/widgets/ship_fitting_context_drawer.dart
@@ -11,14 +11,17 @@ import '../../../widgets/search_bar.dart';
 class ShipFittingContextDrawer extends StatefulWidget {
   final MarketGroup marketGroup;
   final List<Item> initialItems;
+  final List<String> blacklistCalCodes;
 
   ShipFittingContextDrawer({
     Key? key,
     MarketGroup? marketGroup,
     List<Item>? initialFilteredItems,
+    List<String>? blacklistCalCodes,
   })  : assert(marketGroup != null || initialFilteredItems != null),
         marketGroup = marketGroup ?? MarketGroup.invalid,
         initialItems = initialFilteredItems ?? [],
+        blacklistCalCodes = blacklistCalCodes ?? [],
         super(key: key);
 
   @override
@@ -108,6 +111,7 @@ class _ShipFittingContextDrawerState extends State<ShipFittingContextDrawer> {
         return MarketGroupTile(
           marketGroup: child,
           onItemSelected: (item) => Navigator.pop(context, item),
+          blacklistCalCodes: widget.blacklistCalCodes,
         );
       },
     );

--- a/lib/repository/item_repository.dart
+++ b/lib/repository/item_repository.dart
@@ -55,6 +55,8 @@ typedef DownloadProgressCallback = void Function(int, int);
 
 class ItemRepository {
   Map<int, MarketGroup> marketGroupMap = {};
+  List<int> _excludeFusionRigs = [];
+  List<int> get excludeFusionRigs => _excludeFusionRigs;
 
   final Map<int, Item> _itemsCache = {};
   final Map<int, Attribute> _attributeCache = {};
@@ -228,6 +230,13 @@ class ItemRepository {
         marketGroupMap[mkg.parentId!]!.children.add(mkg);
       }
     }
+  }
+
+  Future<void> processExcludeFusionRigs() async {
+    // There are rigs (at the time of writing only the higgs anchors), that
+    // can't be integrated and have to get filtered out of the fitting menu for
+    // integrated rigs.
+    _excludeFusionRigs = [for (var id in await getExcludeFusionRigs()) id];
   }
 
   Future<Iterable<FittingSkill>> fittingSkillsFromDbSkills() async {

--- a/lib/repository/item_repository_db_functions.dart
+++ b/lib/repository/item_repository_db_functions.dart
@@ -248,6 +248,15 @@ extension ItemRepositoryDb on ItemRepository {
     return value;
   }
 
+  Future<Iterable<int>> getExcludeFusionRigs() async {
+    return await _echoesDatabase.db.rawQuery('''
+      SELECT itemId FROM item_attributes
+      WHERE attributeId = 193 AND value <> 0.0;
+     ''').then(
+        (rows) => rows.map((r) => r["itemId"] as int? ?? 0).where((id) => id != 0)
+    );
+  }
+
   Future<Iterable<ItemAttributeValue>> attributeIdsForItem(
           {required Item item}) async =>
       await _echoesDatabase.itemAttributeDao.selectForItem(itemId: item.id);


### PR DESCRIPTION
It was possible to add higgs anchor rigs (which can't be integrated) into integrated rigs. There is now a blacklist of item ids that have the `Cannot be integrated` attribute (id `193`) that gets loaded on startup (thanks @SilkyPantsDan for the guide). For more details refer to the issue sweet-org/sweet#5.

Fixes sweet-org/sweet#5