### PR TITLE
Added Folders, Structures and QOL Features

### DIFF
--- a/lib/bloc/data_loading_bloc/data_loading_bloc.dart
+++ b/lib/bloc/data_loading_bloc/data_loading_bloc.dart
@@ -4,6 +4,8 @@ import 'dart:io';
 import 'package:bloc/bloc.dart';
 import 'package:manup/manup.dart';
 import 'package:sweet/model/character/character.dart';
+import 'package:sweet/model/ship/fitting_list_element.dart';
+import 'package:sweet/model/ship/ship_fitting_folder.dart';
 import 'package:sweet/model/ship/ship_fitting_loadout.dart';
 
 import 'package:sweet/service/fitting_simulator.dart';
@@ -137,7 +139,7 @@ class DataLoadingBloc extends Bloc<DataLoadingBlocEvent, DataLoadingBlocState> {
 
       emit(RepositoryLoadException(
         message: 'Unknown exception',
-        exception: e as Exception?,
+        exception: e is Exception ? e as Exception? : e,
         stackTrace: stacktrace,
       ));
     }
@@ -173,9 +175,18 @@ class DataLoadingBloc extends Bloc<DataLoadingBlocEvent, DataLoadingBlocState> {
         (x) => Character.fromJson(x),
       ),
     );
-    final fittings = List<ShipFittingLoadout>.from(
+    final fittings = List<FittingListElement>.from(
       data['fittings'].map(
-        (x) => ShipFittingLoadout.fromJson(x),
+        (x) => {
+          if (x['type'] == null || x['type'] == 'LOADOUT') {
+            ShipFittingLoadout.fromJson(x)
+          } else if (x['type'] == "FOLDER") {
+            ShipFittingFolder.fromJson(x)
+          } else {
+            //Should never happen
+            null
+          }
+        }
       ),
     );
 

--- a/lib/bloc/item_repository_bloc/market_group_filters.dart
+++ b/lib/bloc/item_repository_bloc/market_group_filters.dart
@@ -18,6 +18,11 @@ enum MarketGroupFilters {
 
   lightweightShips,
   all,
+  structures,
+  pos,
+  structureWeapons,
+  structureModules,
+  structureServices,
 }
 
 final kMidslotExcludeMarketGroups = [
@@ -41,6 +46,16 @@ extension MarketGroupFilterExtension on MarketGroupFilters {
     switch (this) {
       case MarketGroupFilters.ship:
         return 1000;
+      case MarketGroupFilters.structures:
+        return 1100;
+      case MarketGroupFilters.pos:
+        return 110000010;
+      case MarketGroupFilters.structureWeapons:
+        return 110001000;
+      case MarketGroupFilters.structureModules:
+        return 110001010;
+      case MarketGroupFilters.structureServices:
+        return 110001020;
       case MarketGroupFilters.highSlot:
         return 1010;
       case MarketGroupFilters.midSlot:

--- a/lib/model/fitting/fitting_rig_integrator.dart
+++ b/lib/model/fitting/fitting_rig_integrator.dart
@@ -207,6 +207,15 @@ class FittingRigIntegrator extends FittingModule {
     _selectedRigs[index] = rig.copyWith(slot: slot, index: index);
   }
 
+  int? findEmptySlot() {
+    for (int i = 0; i < _selectedRigs.length; i++) {
+      if (_selectedRigs[i] == FittingModule.empty) {
+        return i;
+      }
+    }
+    return null;
+  }
+
   FittingModule rigAtIndex(int index) {
     if (_selectedRigs.length < index) return FittingModule.empty;
     return _selectedRigs[index];

--- a/lib/model/fitting/fitting_skill.dart
+++ b/lib/model/fitting/fitting_skill.dart
@@ -2,8 +2,14 @@ import 'package:sweet/database/entities/entities.dart';
 
 import 'fitting_item.dart';
 
+final regexBasic = RegExp(r"^/Skill/.+/Basic/.+$");
+final regexAdvanced = RegExp(r"^/Skill/.+/Advan/.+$");
+final regexExpert = RegExp(r"^/Skill/.+/Speci/.+$");
+
 class FittingSkill extends FittingItem {
   final int skillLevel;
+  SkillLevelType? _levelType;
+  SkillLevelType? get levelType => _levelType;
 
   FittingSkill({
     required this.skillLevel,
@@ -14,7 +20,9 @@ class FittingSkill extends FittingItem {
           item: item,
           baseAttributes: baseAttributes,
           modifiers: modifiers,
-        );
+        ) {
+    findLevelType();
+  }
 
   FittingSkill copyWith({required int skillLevel}) => FittingSkill(
         skillLevel: skillLevel,
@@ -22,4 +30,27 @@ class FittingSkill extends FittingItem {
         baseAttributes: baseAttributes,
         modifiers: modifiers,
       );
+
+  void findLevelType() {
+    if (item.mainCalCode == null) {
+      print("Skill ${item.id} has no main cal code");
+      return;
+    }
+    if (regexBasic.hasMatch(item.mainCalCode ?? "")) {
+      _levelType = SkillLevelType.basic;
+    } else if (regexAdvanced.hasMatch(item.mainCalCode ?? "")) {
+      _levelType = SkillLevelType.advanced;
+    } else if (regexExpert.hasMatch(item.mainCalCode ?? "")) {
+      _levelType = SkillLevelType.expert;
+    } else {
+      print("Skill ${item.id} has unknown main cal code ${item.mainCalCode}");
+    }
+  }
+
+}
+
+enum SkillLevelType {
+  basic,
+  advanced,
+  expert
 }

--- a/lib/model/items/eve_echoes_categories.dart
+++ b/lib/model/items/eve_echoes_categories.dart
@@ -24,6 +24,7 @@ enum EveEchoesCategory {
   structureModuleBlueprint,
   commodityBlueprint,
   accessoriesBlueprint,
+  structure,
 }
 
 extension CategoryIdExtension on EveEchoesCategory {
@@ -37,6 +38,8 @@ extension CategoryIdExtension on EveEchoesCategory {
         return 10;
       case EveEchoesCategory.modules:
         return 11;
+      case EveEchoesCategory.structure:
+        return 23;
       case EveEchoesCategory.skills:
         return 49;
       case EveEchoesCategory.minerals:

--- a/lib/model/ship/fitting_list_element.dart
+++ b/lib/model/ship/fitting_list_element.dart
@@ -1,0 +1,20 @@
+
+import 'package:sweet/model/ship/ship_fitting_folder.dart';
+import 'package:sweet/model/ship/ship_fitting_loadout.dart';
+
+abstract class FittingListElement {
+  String getId();
+  String getName();
+  Map<String, dynamic> toJson();
+
+  factory FittingListElement.fromJson(Map<String, dynamic> json) {
+    if (json['type'] == null || json['type'] == 'LOADOUT') {
+      return ShipFittingLoadout.fromJson(json);
+    } else if (json['type'] == "FOLDER") {
+      return ShipFittingFolder.fromJson(json);
+    } else {
+      print('Unknown json object $json');
+      throw FormatException('Unknown JSON FittingListElement type: ${json["type"]}');
+    }
+  }
+}

--- a/lib/model/ship/ship_fitting_folder.dart
+++ b/lib/model/ship/ship_fitting_folder.dart
@@ -1,0 +1,105 @@
+
+import 'package:collection/collection.dart';
+import 'package:equatable/equatable.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:sweet/model/ship/fitting_list_element.dart';
+import 'package:sweet/model/ship/ship_fitting_loadout.dart';
+import 'package:uuid/uuid.dart';
+
+part 'ship_fitting_folder.g.dart';
+
+@JsonSerializable()
+class ShipFittingFolder extends ChangeNotifier with FittingListElement, EquatableMixin {
+  final String _id;
+  final String _type = 'FOLDER';
+  final List<FittingListElement> _contents;
+
+  static String get defaultName => 'Unnamed Folder';
+
+  String get id => _id;
+  String _name;
+  String get name => _name;
+  String get type => _type;
+
+  List<FittingListElement> get contents => _contents;
+
+  @override
+  String getId() => _id;
+
+  @override
+  String getName() => _name;
+
+  void setName(String newName) {
+    _name = newName;
+    notifyListeners();
+  }
+
+  FittingListElement? getElement(String elementId) {
+    FittingListElement? target = _contents.firstWhereOrNull((c) => c.getId() == elementId);
+    if (target != null) {
+      return target;
+    }
+    ShipFittingFolder? folder = _contents.whereType<ShipFittingFolder>().firstWhereOrNull((f) => f.hasElement(elementId));
+    if (folder != null) {
+      return folder.getElement(elementId);
+    }
+    return null;
+  }
+
+  List<ShipFittingFolder> getAllSubFolders() {
+    List<ShipFittingFolder> res = [];
+    for (ShipFittingFolder folder in _contents.whereType<ShipFittingFolder>()) {
+      res.add(folder);
+      res.addAll(folder.getAllSubFolders());
+    }
+    return res;
+  }
+
+  bool hasElement(String elementId) => getElement(elementId) != null;
+
+  void deleteElement(String elementId) {
+    _contents.removeWhere((loadout) => loadout.getId() == elementId);
+    //Delete also recursively
+    _contents.whereType<ShipFittingFolder>().forEach((folder) => folder.deleteElement(elementId));
+  }
+
+  ShipFittingFolder? findFolderOf(String elementId) {
+    ShipFittingFolder? folder = _contents.whereType<ShipFittingFolder>().firstWhereOrNull((f) => f.hasElement(elementId));
+    if (folder == null) {
+      return null;
+    }
+    // Check if the element is in this current folder or in a subfolder
+    ShipFittingFolder? subFolder = folder.findFolderOf(elementId);
+    return subFolder ?? folder;
+  }
+
+  int getSize() {
+    int counter = 0;
+    counter += _contents.whereType<ShipFittingLoadout>().length;
+    _contents.whereType<ShipFittingFolder>().forEach((element) {
+      counter += element.getSize();
+    });
+    return counter;
+  }
+
+  ShipFittingFolder({
+    String? id,
+    required String name,
+    List<FittingListElement>? contents,
+    String? type  // Only attributes included in the constructor are serialized
+  })  : _id = id ?? Uuid().v1(),
+        _name = name,
+        _contents = contents ?? [];
+
+  factory ShipFittingFolder.fromJson(Map<String, dynamic> json) {
+    return _$ShipFittingFolderFromJson(json);
+  }
+
+  Map<String, dynamic> toJson() => _$ShipFittingFolderToJson(this);
+
+  @override
+  List<Object?> get props => [
+    name
+  ];
+}

--- a/lib/model/ship/ship_fitting_folder.g.dart
+++ b/lib/model/ship/ship_fitting_folder.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'ship_fitting_folder.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+ShipFittingFolder _$ShipFittingFolderFromJson(Map<String, dynamic> json) =>
+    ShipFittingFolder(
+      id: json['id'] as String?,
+      name: json['name'] as String,
+      contents: (json['contents'] as List<dynamic>?)
+          ?.map((e) => FittingListElement.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      type: json['type'] as String?,
+    );
+
+Map<String, dynamic> _$ShipFittingFolderToJson(ShipFittingFolder instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'type': instance.type,
+      'contents': instance.contents,
+    };

--- a/lib/model/ship/ship_fitting_loadout.dart
+++ b/lib/model/ship/ship_fitting_loadout.dart
@@ -5,6 +5,8 @@ import 'package:equatable/equatable.dart';
 import 'package:flutter/widgets.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:sweet/model/fitting/fitting_module.dart';
+import 'package:sweet/model/ship/fitting_list_element.dart';
+import 'package:sweet/model/ship/ship_fitting_folder.dart';
 import 'package:sweet/model/ship/ship_fitting_slot_module.dart';
 import 'package:sweet/model/ship/slot_type.dart';
 import 'package:uuid/uuid.dart';
@@ -15,19 +17,39 @@ import 'ship_loadout_definition.dart';
 
 part 'ship_fitting_loadout.g.dart';
 
-List<ShipFittingLoadout> loadoutsFromJson(String str) =>
-    List<ShipFittingLoadout>.from(
-        jsonDecode(str).map((x) => ShipFittingLoadout.fromJson(x)));
+List<FittingListElement> loadoutsFromJson(String str) =>
+    List<FittingListElement>.from(jsonDecode(str).map((x) {
+      if (x['type'] == null || x['type'] == 'LOADOUT') {
+        return ShipFittingLoadout.fromJson(x);
+      } else if (x['type'] == "FOLDER") {
+        return ShipFittingFolder.fromJson(x);
+      } else {
+        print("Unknown json object $x");
+        return null;
+      }
+    }));
 
 @JsonSerializable()
-class ShipFittingLoadout extends ChangeNotifier with EquatableMixin {
+class ShipFittingLoadout extends ChangeNotifier
+    with FittingListElement, EquatableMixin {
   final String _id;
+  final String _type = 'LOADOUT';
 
   static String get defaultName => 'Unnamed Fitting';
+
   String get id => _id;
   final int shipItemId;
   String _name;
+
   String get name => _name;
+  String get type => _type;
+
+  @override
+  String getId() => _id;
+
+  @override
+  String getName() => _name;
+
   void setName(String newName) {
     _name = newName;
     notifyListeners();
@@ -58,6 +80,7 @@ class ShipFittingLoadout extends ChangeNotifier with EquatableMixin {
     required this.lightFrigatesSlots,
     required this.lightDestroyersSlots,
     required this.hangarRigSlots,
+    String? type,  // Only attributes included in the constructor are serialized
   })  : _id = id ?? Uuid().v1(),
         _name = name;
 

--- a/lib/model/ship/ship_fitting_loadout.g.dart
+++ b/lib/model/ship/ship_fitting_loadout.g.dart
@@ -31,6 +31,7 @@ ShipFittingLoadout _$ShipFittingLoadoutFromJson(Map<String, dynamic> json) =>
           json['lightDestroyersSlots'] as Map<String, dynamic>),
       hangarRigSlots: ShipFittingSlot.fromJson(
           json['hangarRigSlots'] as Map<String, dynamic>),
+      type: json['type'] as String?,
     );
 
 Map<String, dynamic> _$ShipFittingLoadoutToJson(ShipFittingLoadout instance) =>
@@ -38,6 +39,7 @@ Map<String, dynamic> _$ShipFittingLoadoutToJson(ShipFittingLoadout instance) =>
       'id': instance.id,
       'shipItemId': instance.shipItemId,
       'name': instance.name,
+      'type': instance.type,
       'highSlots': instance.highSlots,
       'midSlots': instance.midSlots,
       'lowSlots': instance.lowSlots,

--- a/lib/pages/character_browser/bloc/character_browser_bloc/bloc.dart
+++ b/lib/pages/character_browser/bloc/character_browser_bloc/bloc.dart
@@ -27,8 +27,19 @@ class CharacterBrowserBloc
     var skillItems = await itemRepository.skillItems;
     emit(CharacterBrowserLoading());
     if (event is AddNewCharacter) {
-      await characterRepository
-          .addCharacter(Character(name: event.characterName));
+      if (event.baseLvl == 0 && event.advLvl == 0 && event.expLvl == 0) {
+        await characterRepository
+            .addCharacter(Character(name: event.characterName));
+      } else {
+        Character character = characterRepository.createAutoSkillCharacter(
+            skills: itemRepository.fittingSkills.values,
+            name: event.characterName,
+            baseLvl: event.baseLvl,
+            advLvl: event.advLvl,
+            expLvl: event.expLvl
+        );
+        await characterRepository.addCharacter(character);
+      }
     }
     if (event is CloneCharacter) {
       await characterRepository.addCharacter(

--- a/lib/pages/character_browser/bloc/character_browser_bloc/events.dart
+++ b/lib/pages/character_browser/bloc/character_browser_bloc/events.dart
@@ -15,11 +15,19 @@ class LoadCharacters extends CharacterBrowserEvent {}
 
 class AddNewCharacter extends CharacterBrowserEvent {
   final String characterName;
+  final int baseLvl;
+  final int advLvl;
+  final int expLvl;
 
-  AddNewCharacter({required this.characterName});
+  AddNewCharacter({
+    required this.characterName,
+    required this.baseLvl,
+    required this.advLvl,
+    required this.expLvl
+  });
 
   @override
-  List<Object> get props => [characterName];
+  List<Object> get props => [characterName, baseLvl, advLvl, expLvl];
 }
 
 class CloneCharacter extends CharacterBrowserEvent {

--- a/lib/pages/character_browser/widget/character_list_view.dart
+++ b/lib/pages/character_browser/widget/character_list_view.dart
@@ -14,8 +14,13 @@ import '../bloc/character_browser_bloc/bloc.dart';
 import '../bloc/character_browser_bloc/events.dart';
 import 'character_card.dart';
 
+final lvlRegex = RegExp(r"^[0-5]$");
+
 class CharacterListView extends StatelessWidget with ScanQrCode {
   final _characterNameController = TextEditingController();
+  final _characterBaseLvlController = TextEditingController();
+  final _characterAdvLvlController = TextEditingController();
+  final _characterExpLvlController = TextEditingController();
 
   Future<void> fittingFromClipboard(BuildContext context) async {
     final data = await Clipboard.getData('text/plain');
@@ -63,6 +68,50 @@ class CharacterListView extends StatelessWidget with ScanQrCode {
                     labelText: 'Character name',
                   ),
                 ),
+                Text("Initial skills"),
+                Row(
+                  children: [
+                    Flexible(
+                      child: TextField(
+                        controller: _characterBaseLvlController,
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp(r"[0-5]"))
+                        ],
+                        decoration: InputDecoration(
+                          border: OutlineInputBorder(),
+                          labelText: 'Basic',
+                        ),
+                      ),
+                    ),
+                    Flexible(
+                      child: TextField(
+                        controller: _characterAdvLvlController,
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp(r"[0-5]"))
+                        ],
+                        decoration: InputDecoration(
+                          border: OutlineInputBorder(),
+                          labelText: 'Adv',
+                        ),
+                      ),
+                    ),
+                    Flexible(
+                      child: TextField(
+                        controller: _characterExpLvlController,
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.allow(RegExp(r"[0-5]"))
+                        ],
+                        decoration: InputDecoration(
+                          border: OutlineInputBorder(),
+                          labelText: 'Exp',
+                        ),
+                      ),
+                    )
+                  ],
+                )
               ],
             ),
           ),
@@ -77,12 +126,26 @@ class CharacterListView extends StatelessWidget with ScanQrCode {
             ),
             TextButton(
               onPressed: () {
-                if (_characterNameController.text.isNotEmpty) {
-                  widgetContext.read<CharacterBrowserBloc>().add(
-                      AddNewCharacter(
-                          characterName: _characterNameController.text));
-                  Navigator.of(context).pop();
+                if (!_characterNameController.text.isNotEmpty) {
+                  return;
                 }
+                if (!checkLvlController(_characterBaseLvlController)) {
+                  return;
+                }
+                if (!checkLvlController(_characterAdvLvlController)) {
+                  return;
+                }
+                if (!checkLvlController(_characterExpLvlController)) {
+                  return;
+                }
+                widgetContext.read<CharacterBrowserBloc>().add(
+                    AddNewCharacter(
+                        characterName: _characterNameController.text,
+                        baseLvl: int.parse(_characterBaseLvlController.text),
+                        advLvl: int.parse(_characterAdvLvlController.text),
+                        expLvl: int.parse(_characterExpLvlController.text)
+                    ));
+                Navigator.of(context).pop();
               },
               child: LocalisedText(localiseId: LocalisationStrings.ok),
             ),
@@ -90,6 +153,16 @@ class CharacterListView extends StatelessWidget with ScanQrCode {
         );
       },
     );
+  }
+
+  bool checkLvlController(TextEditingController controller) {
+    if (controller.text.isEmpty) {
+      controller.text = "0";
+    }
+    if (!lvlRegex.hasMatch(controller.text)) {
+      return false;
+    }
+    return true;
   }
 
   @override

--- a/lib/pages/character_browser/widget/character_list_view.dart
+++ b/lib/pages/character_browser/widget/character_list_view.dart
@@ -16,6 +16,41 @@ import 'character_card.dart';
 
 final lvlRegex = RegExp(r"^[0-5]$");
 
+bool checkLvlController(TextEditingController controller) {
+  if (controller.text.isEmpty) {
+    controller.text = "0";
+  }
+  if (!lvlRegex.hasMatch(controller.text)) {
+    return false;
+  }
+  return true;
+}
+
+bool isValidLvlInput(
+    {required TextEditingController baseController,
+    required TextEditingController advController,
+    required TextEditingController expController}) {
+  if (!checkLvlController(baseController)) {
+    return false;
+  }
+  if (!checkLvlController(advController)) {
+    return false;
+  }
+  if (!checkLvlController(expController)) {
+    return false;
+  }
+  int base = int.parse(baseController.text);
+  int adv = int.parse(advController.text);
+  int exp = int.parse(expController.text);
+  if (exp > 0 && adv < 5) {
+    return false;
+  }
+  if (adv > 0 && base < 4) {
+    return false;
+  }
+  return true;
+}
+
 class CharacterListView extends StatelessWidget with ScanQrCode {
   final _characterNameController = TextEditingController();
   final _characterBaseLvlController = TextEditingController();
@@ -129,22 +164,17 @@ class CharacterListView extends StatelessWidget with ScanQrCode {
                 if (!_characterNameController.text.isNotEmpty) {
                   return;
                 }
-                if (!checkLvlController(_characterBaseLvlController)) {
+                if (!isValidLvlInput(
+                    baseController: _characterBaseLvlController,
+                    advController: _characterAdvLvlController,
+                    expController: _characterExpLvlController)) {
                   return;
                 }
-                if (!checkLvlController(_characterAdvLvlController)) {
-                  return;
-                }
-                if (!checkLvlController(_characterExpLvlController)) {
-                  return;
-                }
-                widgetContext.read<CharacterBrowserBloc>().add(
-                    AddNewCharacter(
-                        characterName: _characterNameController.text,
-                        baseLvl: int.parse(_characterBaseLvlController.text),
-                        advLvl: int.parse(_characterAdvLvlController.text),
-                        expLvl: int.parse(_characterExpLvlController.text)
-                    ));
+                widgetContext.read<CharacterBrowserBloc>().add(AddNewCharacter(
+                    characterName: _characterNameController.text,
+                    baseLvl: int.parse(_characterBaseLvlController.text),
+                    advLvl: int.parse(_characterAdvLvlController.text),
+                    expLvl: int.parse(_characterExpLvlController.text)));
                 Navigator.of(context).pop();
               },
               child: LocalisedText(localiseId: LocalisationStrings.ok),
@@ -153,16 +183,6 @@ class CharacterListView extends StatelessWidget with ScanQrCode {
         );
       },
     );
-  }
-
-  bool checkLvlController(TextEditingController controller) {
-    if (controller.text.isEmpty) {
-      controller.text = "0";
-    }
-    if (!lvlRegex.hasMatch(controller.text)) {
-      return false;
-    }
-    return true;
   }
 
   @override

--- a/lib/pages/fittings_list/bloc/ship_fitting_browser_bloc/bloc.dart
+++ b/lib/pages/fittings_list/bloc/ship_fitting_browser_bloc/bloc.dart
@@ -1,4 +1,5 @@
 import 'package:bloc/bloc.dart';
+import 'package:sweet/model/ship/ship_fitting_folder.dart';
 import 'package:sweet/model/ship/ship_fitting_loadout.dart';
 import 'package:sweet/repository/item_repository.dart';
 import 'package:sweet/repository/ship_fitting_repository.dart';
@@ -33,6 +34,28 @@ class ShipFittingBrowserBloc
       emit(ShipFittingBrowserLoaded(fittingRepository.loadouts));
     }
 
+    if (event is CreateFittingFolder) {
+      emit(ShipFittingBrowserLoading());
+      var folder = ShipFittingFolder(name: "Unnamed Folder");
+      await fittingRepository.addLoadout(folder);
+      emit(ShipFittingBrowserLoaded(fittingRepository.loadouts));
+    }
+
+    if (event is RenameFittingFolder) {
+      emit(ShipFittingBrowserLoading());
+      event.folder.setName(event.newName);
+      await fittingRepository.saveLoadouts();
+      emit(ShipFittingBrowserLoaded(fittingRepository.loadouts));
+    }
+
+    if (event is MoveFittingToFolder) {
+      emit(ShipFittingBrowserLoading());
+      await fittingRepository.moveToFolder(
+          loadout: event.fitting, folderName: event.folderName
+      );
+      emit(ShipFittingBrowserLoaded(fittingRepository.loadouts));
+    }
+
     if (event is DeleteShipFitting) {
       emit(ShipFittingBrowserLoading());
       await fittingRepository.deleteLoadout(loadoutId: event.shipFittingId);
@@ -63,7 +86,7 @@ class ShipFittingBrowserBloc
     if (event is ReorderShipFitting) {
       emit(ShipFittingBrowserLoading());
       await fittingRepository.moveFitting(
-        fitting: event.shipFitting,
+        element: event.element,
         newIndex: event.newIndex,
       );
       emit(ShipFittingBrowserLoaded(fittingRepository.loadouts));

--- a/lib/pages/fittings_list/bloc/ship_fitting_browser_bloc/bloc.dart
+++ b/lib/pages/fittings_list/bloc/ship_fitting_browser_bloc/bloc.dart
@@ -51,7 +51,7 @@ class ShipFittingBrowserBloc
     if (event is MoveFittingToFolder) {
       emit(ShipFittingBrowserLoading());
       await fittingRepository.moveToFolder(
-          loadout: event.fitting, folderName: event.folderName
+          loadout: event.fitting, folderId: event.folderId
       );
       emit(ShipFittingBrowserLoaded(fittingRepository.loadouts));
     }

--- a/lib/pages/fittings_list/bloc/ship_fitting_browser_bloc/bloc.dart
+++ b/lib/pages/fittings_list/bloc/ship_fitting_browser_bloc/bloc.dart
@@ -88,6 +88,7 @@ class ShipFittingBrowserBloc
       await fittingRepository.moveFitting(
         element: event.element,
         newIndex: event.newIndex,
+        folder: event.folder
       );
       emit(ShipFittingBrowserLoaded(fittingRepository.loadouts));
     }

--- a/lib/pages/fittings_list/bloc/ship_fitting_browser_bloc/events.dart
+++ b/lib/pages/fittings_list/bloc/ship_fitting_browser_bloc/events.dart
@@ -36,15 +36,15 @@ class CreateFittingFolder extends ShipFittingBrowserEvent {
 }
 
 class MoveFittingToFolder extends ShipFittingBrowserEvent {
-  final String folderName;
+  final String folderId;
   final FittingListElement fitting;
 
-  MoveFittingToFolder(this.fitting, this.folderName);
+  MoveFittingToFolder(this.fitting, this.folderId);
 
   @override
   List<Object> get props => [
     fitting,
-    folderName,
+    folderId,
   ];
 }
 

--- a/lib/pages/fittings_list/bloc/ship_fitting_browser_bloc/events.dart
+++ b/lib/pages/fittings_list/bloc/ship_fitting_browser_bloc/events.dart
@@ -1,6 +1,8 @@
 
 
 import 'package:sweet/database/entities/item.dart';
+import 'package:sweet/model/ship/fitting_list_element.dart';
+import 'package:sweet/model/ship/ship_fitting_folder.dart';
 import 'package:sweet/model/ship/ship_fitting_loadout.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/widgets.dart';
@@ -23,6 +25,27 @@ class CreateShipFitting extends ShipFittingBrowserEvent {
         name,
         ship,
       ];
+}
+
+class CreateFittingFolder extends ShipFittingBrowserEvent {
+
+  CreateFittingFolder();
+
+  @override
+  List<Object> get props => [];
+}
+
+class MoveFittingToFolder extends ShipFittingBrowserEvent {
+  final String folderName;
+  final FittingListElement fitting;
+
+  MoveFittingToFolder(this.fitting, this.folderName);
+
+  @override
+  List<Object> get props => [
+    fitting,
+    folderName,
+  ];
 }
 
 class LoadAllShipFittings extends ShipFittingBrowserEvent {
@@ -76,17 +99,33 @@ class DeleteShipFitting extends ShipFittingBrowserEvent {
 }
 
 class ReorderShipFitting extends ShipFittingBrowserEvent {
-  final ShipFittingLoadout shipFitting;
+  final FittingListElement element;
   final int newIndex;
 
   ReorderShipFitting({
-    required this.shipFitting,
+    required this.element,
     required this.newIndex,
   });
 
   @override
   List<Object> get props => [
-        shipFitting,
+    element,
         newIndex,
       ];
+}
+
+class RenameFittingFolder extends ShipFittingBrowserEvent {
+  final ShipFittingFolder folder;
+  final String newName;
+
+  RenameFittingFolder({
+    required this.folder,
+    required this.newName,
+  });
+
+  @override
+  List<Object> get props => [
+    folder,
+    newName,
+  ];
 }

--- a/lib/pages/fittings_list/bloc/ship_fitting_browser_bloc/events.dart
+++ b/lib/pages/fittings_list/bloc/ship_fitting_browser_bloc/events.dart
@@ -1,5 +1,3 @@
-
-
 import 'package:sweet/database/entities/item.dart';
 import 'package:sweet/model/ship/fitting_list_element.dart';
 import 'package:sweet/model/ship/ship_fitting_folder.dart';
@@ -10,7 +8,8 @@ import 'package:flutter/widgets.dart';
 @immutable
 abstract class ShipFittingBrowserEvent extends Equatable {
   @override
-  List<Object> get props => [];
+  List<Object?> get props => [];
+
   ShipFittingBrowserEvent([List props = const []]) : super();
 }
 
@@ -28,7 +27,6 @@ class CreateShipFitting extends ShipFittingBrowserEvent {
 }
 
 class CreateFittingFolder extends ShipFittingBrowserEvent {
-
   CreateFittingFolder();
 
   @override
@@ -43,9 +41,9 @@ class MoveFittingToFolder extends ShipFittingBrowserEvent {
 
   @override
   List<Object> get props => [
-    fitting,
-    folderId,
-  ];
+        fitting,
+        folderId,
+      ];
 }
 
 class LoadAllShipFittings extends ShipFittingBrowserEvent {
@@ -101,16 +99,16 @@ class DeleteShipFitting extends ShipFittingBrowserEvent {
 class ReorderShipFitting extends ShipFittingBrowserEvent {
   final FittingListElement element;
   final int newIndex;
+  final ShipFittingFolder? folder;
 
-  ReorderShipFitting({
-    required this.element,
-    required this.newIndex,
-  });
+  ReorderShipFitting(
+      {required this.element, required this.newIndex, this.folder});
 
   @override
-  List<Object> get props => [
-    element,
+  List<Object?> get props => [
+        element,
         newIndex,
+        folder
       ];
 }
 
@@ -125,7 +123,7 @@ class RenameFittingFolder extends ShipFittingBrowserEvent {
 
   @override
   List<Object> get props => [
-    folder,
-    newName,
-  ];
+        folder,
+        newName,
+      ];
 }

--- a/lib/pages/fittings_list/bloc/ship_fitting_browser_bloc/states.dart
+++ b/lib/pages/fittings_list/bloc/ship_fitting_browser_bloc/states.dart
@@ -1,6 +1,6 @@
 
 
-import 'package:sweet/model/ship/ship_fitting_loadout.dart';
+import 'package:sweet/model/ship/fitting_list_element.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/widgets.dart';
 
@@ -14,7 +14,7 @@ abstract class ShipFittingBrowserState extends Equatable {
 class ShipFittingBrowserLoading extends ShipFittingBrowserState {}
 
 class ShipFittingBrowserLoaded extends ShipFittingBrowserState {
-  final Iterable<ShipFittingLoadout> fittings;
+  final Iterable<FittingListElement> fittings;
 
   ShipFittingBrowserLoaded(this.fittings);
 

--- a/lib/pages/fittings_list/widgets/fitting_folder_card.dart
+++ b/lib/pages/fittings_list/widgets/fitting_folder_card.dart
@@ -160,10 +160,7 @@ class _FittingFolderState extends State<FittingFolderCard> {
           content: SingleChildScrollView(
             child: ListBody(
               children: <Widget>[
-                Text(
-                    'Please enter the new name of the folder\n\nNames should be '
-                        'unique, or else you won\'t be able to move fittings '
-                        'into the folder.'),
+                Text('Please enter the new name of the folder\n'),
                 TextField(
                   controller: folderController,
                   decoration: InputDecoration(

--- a/lib/pages/fittings_list/widgets/fitting_folder_card.dart
+++ b/lib/pages/fittings_list/widgets/fitting_folder_card.dart
@@ -1,0 +1,252 @@
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:provider/provider.dart';
+import 'package:sweet/model/ship/ship_fitting_folder.dart';
+
+import 'package:sweet/model/ship/ship_fitting_loadout.dart';
+import 'package:sweet/pages/fittings_list/bloc/ship_fitting_browser_bloc/bloc.dart';
+import 'package:sweet/pages/fittings_list/bloc/ship_fitting_browser_bloc/events.dart';
+import 'package:sweet/pages/fittings_list/widgets/ship_fitting_card.dart';
+import 'package:sweet/util/localisation_constants.dart';
+import 'package:sweet/widgets/localised_text.dart';
+
+/// Represents a folder that can contains multiple ship fittings.
+class FittingFolderCard extends StatefulWidget {
+  final ShipFittingFolder folder;
+  final Future<void> Function(ShipFittingLoadout loadout) onLoadoutTap;
+  // TODO: Make content rearrange-able
+
+  const FittingFolderCard(
+      {Key? key, required this.folder, required this.onLoadoutTap})
+      : super(key: key);
+
+  @override
+  State<StatefulWidget> createState() => _FittingFolderState();
+}
+
+class _FittingFolderState extends State<FittingFolderCard> {
+  bool _isExpaned = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider.value(
+      value: widget.folder,
+      child: Card(
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: _toggleFolder,
+          child: ConstrainedBox(
+            constraints: BoxConstraints(minHeight: 72),
+            child: Padding(
+              padding: const EdgeInsets.only(
+                top: 8.0,
+                bottom: 8.0,
+                left: 8.0,
+                right: 32.0,
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.only(right: 8.0),
+                        child: Icon(
+                          _isExpaned ? Icons.folder_open : Icons.folder,
+                          size: 48.0,
+                        ),
+                      ),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            AutoSizeText(
+                              widget.folder.name,
+                              style: Theme
+                                  .of(context)
+                                  .textTheme
+                                  .titleLarge,
+                              maxLines: 1,
+                            ),
+                            AutoSizeText(
+                              _isExpaned ? "Tap to close" : "Tap to open",
+                              style: Theme
+                                  .of(context)
+                                  .textTheme
+                                  .bodyMedium,
+                              maxLines: 1,
+                            ),
+                            AutoSizeText(
+                              widget.folder.getSize().toString() +
+                                  (widget.folder.getSize() == 1
+                                      ? " Fitting"
+                                      : " Fittings"),
+                              style: Theme
+                                  .of(context)
+                                  .textTheme
+                                  .bodyMedium,
+                              maxLines: 1,
+                            )
+                          ],
+                        ),
+                      ),
+                      IconButton(
+                        icon: Icon(Icons.edit),
+                        onPressed: () => renameFolder(context, widget.folder),
+                      ),
+                      IconButton(
+                        icon: Icon(Icons.delete),
+                        onPressed: () => deleteFolder(context, widget.folder),
+                      ),
+                    ],
+                  ),
+                  _isExpaned
+                      ? Container(
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(4),
+                      color: Theme
+                          .of(context)
+                          .dividerColor,
+                    ),
+                    child: ListView.builder(
+                        itemCount: widget.folder.contents.length,
+                        physics: NeverScrollableScrollPhysics(),
+                        shrinkWrap: true,
+                        itemBuilder: (context, index) {
+                          var loadout = widget.folder.contents[index];
+                          if (loadout is ShipFittingLoadout) {
+                            return ShipFittingCard(
+                              key: Key(loadout.getId()),
+                              loadout: loadout,
+                              onTap: widget.onLoadoutTap,
+                            );
+                          } else if (loadout is ShipFittingFolder) {
+                            return FittingFolderCard(
+                                key: Key(loadout.getId()),
+                                folder: loadout,
+                                onLoadoutTap: widget.onLoadoutTap);
+                          } else {
+                            return Text(
+                                "Error, unknown element: ${loadout.getId()}\n${loadout.getName()}");
+                          }
+                        }),
+                  )
+                      : Container()
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _toggleFolder() {
+    setState(() {
+      _isExpaned = !_isExpaned;
+    });
+  }
+
+  Future<void> renameFolder(BuildContext widgetContext,
+      ShipFittingFolder folder) {
+    final folderController = TextEditingController(text: folder.name);
+    return showDialog<void>(
+      context: widgetContext,
+      barrierDismissible: false,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: Text(StaticLocalisationStrings.renameFolder),
+          content: SingleChildScrollView(
+            child: ListBody(
+              children: <Widget>[
+                Text(
+                    'Please enter the new name of the folder\n\nNames should be '
+                        'unique, or else you won\'t be able to move fittings '
+                        'into the folder.'),
+                TextField(
+                  controller: folderController,
+                  decoration: InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'New Folder Name',
+                  ),
+                ),
+              ],
+            ),
+          ),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+              child: LocalisedText(
+                localiseId: LocalisationStrings.cancel,
+              ),
+            ),
+            TextButton(
+              onPressed: () {
+                widgetContext
+                    .read<ShipFittingBrowserBloc>()
+                    .add(RenameFittingFolder(
+                    folder: widget.folder, newName: folderController.text));
+                Navigator.of(context).pop();
+              },
+              child: LocalisedText(localiseId: LocalisationStrings.ok),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Future<void> deleteFolder(
+      BuildContext widgetContext, ShipFittingFolder folder) {
+    //ToDo: Merge with deleteFolder in ship_fitting_card.dart?
+    return showDialog<void>(
+      context: widgetContext,
+      barrierDismissible: false, // user must tap button!
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: Text(StaticLocalisationStrings.deleteFolder),
+          backgroundColor: Colors.deepOrangeAccent,
+          content: Text(
+              'Are you sure you want to delete this folder? This will include ALL it\'s contents!'
+                  '\n\nThis action cannot be reversed.'),
+          actions: <Widget>[
+            Container(
+              decoration: BoxDecoration(
+                color: Theme.of(context).cardColor,
+                borderRadius: BorderRadius.circular(8)
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  TextButton(
+                    onPressed: () {
+                      Navigator.of(context).pop();
+                    },
+                    child: LocalisedText(
+                      localiseId: LocalisationStrings.cancel,
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.only(left: 16.0),
+                    child: TextButton(
+                      onPressed: () {
+                        widgetContext
+                            .read<ShipFittingBrowserBloc>()
+                            .add(DeleteShipFitting(shipFittingId: folder.id));
+                        Navigator.of(context).pop();
+                      },
+                      child: LocalisedText(localiseId: LocalisationStrings.ok),
+                    ),
+                  ),
+                ],
+              ),
+            )
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/pages/fittings_list/widgets/fitting_folder_card.dart
+++ b/lib/pages/fittings_list/widgets/fitting_folder_card.dart
@@ -1,6 +1,5 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:provider/provider.dart';
 import 'package:sweet/model/ship/ship_fitting_folder.dart';
 
@@ -15,7 +14,6 @@ import 'package:sweet/widgets/localised_text.dart';
 class FittingFolderCard extends StatefulWidget {
   final ShipFittingFolder folder;
   final Future<void> Function(ShipFittingLoadout loadout) onLoadoutTap;
-  // TODO: Make content rearrange-able
 
   const FittingFolderCard(
       {Key? key, required this.folder, required this.onLoadoutTap})
@@ -109,10 +107,26 @@ class _FittingFolderState extends State<FittingFolderCard> {
                           .of(context)
                           .dividerColor,
                     ),
-                    child: ListView.builder(
+                    child: ReorderableListView.builder(
                         itemCount: widget.folder.contents.length,
                         physics: NeverScrollableScrollPhysics(),
                         shrinkWrap: true,
+                        onReorder: (oldIndex, newIndex) {
+                          final fitting = widget.folder.contents[oldIndex];
+                          if (oldIndex < newIndex) {
+                            // removing the item at oldIndex will shorten the list by 1.
+                            // https://api.flutter.dev/flutter/widgets/ReorderCallback.html
+                            newIndex -= 1;
+                          }
+
+                          context.read<ShipFittingBrowserBloc>().add(
+                            ReorderShipFitting(
+                                element: fitting,
+                                newIndex: newIndex,
+                                folder: widget.folder
+                            ),
+                          );
+                        },
                         itemBuilder: (context, index) {
                           var loadout = widget.folder.contents[index];
                           if (loadout is ShipFittingLoadout) {

--- a/lib/pages/fittings_list/widgets/fitting_folder_card.dart
+++ b/lib/pages/fittings_list/widgets/fitting_folder_card.dart
@@ -219,9 +219,8 @@ class _FittingFolderState extends State<FittingFolderCard> {
       builder: (BuildContext context) {
         return AlertDialog(
           title: Text(StaticLocalisationStrings.deleteFolder),
-          backgroundColor: Colors.deepOrangeAccent,
           content: Text(
-              'Are you sure you want to delete this folder? This will include ALL it\'s contents!'
+              'Are you sure you want to delete this folder? This will include ALL of it\'s contents!'
                   '\n\nThis action cannot be reversed.'),
           actions: <Widget>[
             Container(

--- a/lib/pages/fittings_list/widgets/fitting_tool_list.dart
+++ b/lib/pages/fittings_list/widgets/fitting_tool_list.dart
@@ -3,6 +3,8 @@ import 'package:sweet/bloc/item_repository_bloc/market_group_filters.dart';
 import 'package:sweet/database/entities/item.dart';
 import 'package:sweet/mixins/scan_qrcode_mixin.dart';
 import 'package:sweet/model/items/eve_echoes_categories.dart';
+import 'package:sweet/model/ship/ship_fitting_folder.dart';
+import 'package:sweet/pages/fittings_list/widgets/fitting_folder_card.dart';
 import 'package:sweet/repository/character_repository.dart';
 import 'package:sweet/service/fitting_simulator.dart';
 import 'package:sweet/model/ship/ship_fitting_loadout.dart';
@@ -61,6 +63,12 @@ class _FittingToolListState extends State<FittingToolList>
     );
 
     await _showFittingPage(loadout);
+  }
+
+  void addFolder() async {
+    context.read<ShipFittingBrowserBloc>().add(
+      CreateFittingFolder(),
+    );
   }
 
   Future<void> _showFittingPage(ShipFittingLoadout loadout) async {
@@ -129,16 +137,26 @@ class _FittingToolListState extends State<FittingToolList>
 
                     context.read<ShipFittingBrowserBloc>().add(
                           ReorderShipFitting(
-                              shipFitting: fitting, newIndex: newIndex),
+                              element: fitting, newIndex: newIndex),
                         );
                   },
                   itemBuilder: (context, index) {
                     var loadout = list[index];
-                    return ShipFittingCard(
-                      key: Key(loadout.id),
-                      loadout: loadout,
-                      onTap: _showFittingPage,
-                    );
+                    if (loadout is ShipFittingLoadout) {
+                      return ShipFittingCard(
+                        key: Key(loadout.getId()),
+                        loadout: loadout,
+                        onTap: _showFittingPage,
+                      );
+                    } else if (loadout is ShipFittingFolder) {
+                      return FittingFolderCard(
+                          key: Key(loadout.getId()),
+                          folder: loadout,
+                          onLoadoutTap: _showFittingPage
+                      );
+                    } else {
+                      return Text("Error, unknown element: ${loadout.getName()}\n${loadout.getId()}");
+                    }
                   },
                 );
               }
@@ -165,6 +183,18 @@ class _FittingToolListState extends State<FittingToolList>
     return SpeedDialFab(
       buttonClosedColor: Theme.of(context).primaryColor,
       children: [
+        SizedBox.fromSize(
+          size: Size.square(48),
+          child: RawMaterialButton(
+            onPressed: () => addFolder(),
+            fillColor: Theme.of(context).primaryColor,
+            shape: CircleBorder(),
+            child: Icon(
+              Icons.create_new_folder,
+              color: Colors.white,
+            ),
+          ),
+        ),
         SizedBox.fromSize(
           size: Size.square(48),
           child: RawMaterialButton(

--- a/lib/pages/fittings_list/widgets/fitting_tool_list.dart
+++ b/lib/pages/fittings_list/widgets/fitting_tool_list.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/services.dart';
 import 'package:sweet/bloc/item_repository_bloc/market_group_filters.dart';
 import 'package:sweet/database/entities/item.dart';
+import 'package:sweet/database/entities/market_group.dart';
 import 'package:sweet/mixins/scan_qrcode_mixin.dart';
 import 'package:sweet/model/items/eve_echoes_categories.dart';
 import 'package:sweet/model/ship/ship_fitting_folder.dart';
@@ -32,18 +33,25 @@ class _FittingToolListState extends State<FittingToolList>
   void showShipList(BuildContext context) async {
     var shipsMarketGroup = RepositoryProvider.of<ItemRepository>(context)
         .marketGroupMap[MarketGroupFilters.ship.marketGroupId];
-
-    if (shipsMarketGroup == null) return;
+    var posMarketGroup = RepositoryProvider.of<ItemRepository>(context)
+        .marketGroupMap[MarketGroupFilters.pos.marketGroupId];
+    var pseudoGroup = MarketGroup(
+        id: -1, iconIndex: -1, localisationIndex: -1, sourceName: "No Name");
+    if (shipsMarketGroup == null && posMarketGroup == null) return;
+    if (shipsMarketGroup != null) pseudoGroup.children.add(shipsMarketGroup);
+    if (posMarketGroup != null) pseudoGroup.children.add(posMarketGroup);
 
     var ship = await showModalBottomSheet<Item?>(
       context: context,
       elevation: 16,
       builder: (context) => ShipFittingContextDrawer(
-        marketGroup: shipsMarketGroup,
+        marketGroup: pseudoGroup,
       ),
     );
 
-    if (ship == null || ship.categoryId != EveEchoesCategory.ships.categoryId) {
+    if (ship == null ||
+        ship.categoryId != EveEchoesCategory.ships.categoryId &&
+            ship.marketGroupId != MarketGroupFilters.pos.marketGroupId) {
       if (ship != null) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(

--- a/lib/pages/fittings_list/widgets/ship_fitting_card.dart
+++ b/lib/pages/fittings_list/widgets/ship_fitting_card.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 import 'package:sweet/model/ship/ship_fitting_loadout.dart';
 import 'package:sweet/pages/fittings_list/bloc/ship_fitting_browser_bloc/ship_fitting_browser_bloc.dart';
 import 'package:sweet/repository/item_repository.dart';
+import 'package:sweet/repository/ship_fitting_repository.dart';
 import 'package:sweet/util/localisation_constants.dart';
 import 'package:sweet/widgets/localised_text.dart';
 
@@ -186,30 +187,37 @@ class ShipFittingCard extends StatelessWidget {
 
   Future<void> moveLoadoutToFolder(
       BuildContext widgetContext, ShipFittingLoadout loadout) {
-    final folderController = TextEditingController(text: '');
+    var fittingRepo =
+        RepositoryProvider.of<ShipFittingLoadoutRepository>(widgetContext);
     //ToDo: Replace with a dropdown or something similar. Drag&Drop would be cool but probably to complicated
     return showDialog<void>(
       context: widgetContext,
       barrierDismissible: false,
       builder: (BuildContext context) {
         return AlertDialog(
-            title: Text(StaticLocalisationStrings.moveToFolder),
-            content: SingleChildScrollView(
-              child: ListBody(
-                children: <Widget>[
-                  Text(
-                      'Please enter the target folder name where you want to move this fitting to.\n\n'
-                      'Empty if you want to move it outside of the current folder.'),
-                  TextField(
-                    controller: folderController,
-                    decoration: InputDecoration(
-                      border: OutlineInputBorder(),
-                      labelText: 'Folder Name',
-                    ),
-                  ),
-                ],
-              ),
+          title: Text(StaticLocalisationStrings.moveToFolder),
+          content: SingleChildScrollView(
+            child: ListBody(
+              children: <Widget>[
+                Text('Select the target folder or press "No Folder" to move it out of the current folder'),
+                DropdownButton<String>(
+                    isExpanded: true,
+                    items: fittingRepo
+                        .getAllFolders()
+                        .map<DropdownMenuItem<String>>((f) => DropdownMenuItem(
+                              child: Text(f.name),
+                              value: f.id,
+                            ))
+                        .toList(),
+                    onChanged: (id) {
+                      widgetContext
+                          .read<ShipFittingBrowserBloc>()
+                          .add(MoveFittingToFolder(loadout, id ?? ""));
+                      Navigator.of(context).pop();
+                    })
+              ],
             ),
+          ),
           actions: <Widget>[
             TextButton(
               onPressed: () {
@@ -223,10 +231,10 @@ class ShipFittingCard extends StatelessWidget {
               onPressed: () {
                 widgetContext
                     .read<ShipFittingBrowserBloc>()
-                    .add(MoveFittingToFolder(loadout, folderController.text));
+                    .add(MoveFittingToFolder(loadout, ""));
                 Navigator.of(context).pop();
               },
-              child: LocalisedText(localiseId: LocalisationStrings.ok),
+              child: Text("No Folder"),
             ),
           ],
         );

--- a/lib/pages/fittings_list/widgets/ship_fitting_card.dart
+++ b/lib/pages/fittings_list/widgets/ship_fitting_card.dart
@@ -74,6 +74,9 @@ class ShipFittingCard extends StatelessWidget {
                     ),
                   ),
                   IconButton(
+                      icon: Icon(Icons.snippet_folder_rounded),
+                      onPressed: () => moveLoadoutToFolder(context, loadout)),
+                  IconButton(
                     icon: Icon(Icons.delete),
                     onPressed: () => deleteLoadout(context, loadout),
                   ),
@@ -171,6 +174,56 @@ class ShipFittingCard extends StatelessWidget {
                 widgetContext
                     .read<ShipFittingBrowserBloc>()
                     .add(DeleteShipFitting(shipFittingId: loadout.id));
+                Navigator.of(context).pop();
+              },
+              child: LocalisedText(localiseId: LocalisationStrings.ok),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Future<void> moveLoadoutToFolder(
+      BuildContext widgetContext, ShipFittingLoadout loadout) {
+    final folderController = TextEditingController(text: '');
+    //ToDo: Replace with a dropdown or something similar. Drag&Drop would be cool but probably to complicated
+    return showDialog<void>(
+      context: widgetContext,
+      barrierDismissible: false,
+      builder: (BuildContext context) {
+        return AlertDialog(
+            title: Text(StaticLocalisationStrings.moveToFolder),
+            content: SingleChildScrollView(
+              child: ListBody(
+                children: <Widget>[
+                  Text(
+                      'Please enter the target folder name where you want to move this fitting to.\n\n'
+                      'Empty if you want to move it outside of the current folder.'),
+                  TextField(
+                    controller: folderController,
+                    decoration: InputDecoration(
+                      border: OutlineInputBorder(),
+                      labelText: 'Folder Name',
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+              child: LocalisedText(
+                localiseId: LocalisationStrings.cancel,
+              ),
+            ),
+            TextButton(
+              onPressed: () {
+                widgetContext
+                    .read<ShipFittingBrowserBloc>()
+                    .add(MoveFittingToFolder(loadout, folderController.text));
                 Navigator.of(context).pop();
               },
               child: LocalisedText(localiseId: LocalisationStrings.ok),

--- a/lib/pages/fittings_list/widgets/ship_fitting_card.dart
+++ b/lib/pages/fittings_list/widgets/ship_fitting_card.dart
@@ -189,7 +189,6 @@ class ShipFittingCard extends StatelessWidget {
       BuildContext widgetContext, ShipFittingLoadout loadout) {
     var fittingRepo =
         RepositoryProvider.of<ShipFittingLoadoutRepository>(widgetContext);
-    //ToDo: Replace with a dropdown or something similar. Drag&Drop would be cool but probably to complicated
     return showDialog<void>(
       context: widgetContext,
       barrierDismissible: false,

--- a/lib/pages/fittings_list/widgets/ship_fitting_card.dart
+++ b/lib/pages/fittings_list/widgets/ship_fitting_card.dart
@@ -74,17 +74,7 @@ class ShipFittingCard extends StatelessWidget {
                       },
                     ),
                   ),
-                  IconButton(
-                      icon: Icon(Icons.snippet_folder_rounded),
-                      onPressed: () => moveLoadoutToFolder(context, loadout)),
-                  IconButton(
-                    icon: Icon(Icons.delete),
-                    onPressed: () => deleteLoadout(context, loadout),
-                  ),
-                  IconButton(
-                    icon: Icon(Icons.file_copy),
-                    onPressed: () => copyLoadout(context, loadout),
-                  ),
+                  FittingControls(loadout: loadout)
                 ],
               ),
             ),
@@ -92,6 +82,52 @@ class ShipFittingCard extends StatelessWidget {
         ),
       ),
     );
+  }
+}
+
+class FittingControls extends StatefulWidget {
+  final ShipFittingLoadout loadout;
+
+  const FittingControls({Key? key, required this.loadout}) : super(key: key);
+
+  @override
+  State<FittingControls> createState() => _FittingControlsState();
+}
+
+class _FittingControlsState extends State<FittingControls> {
+  bool _isExpanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return _isExpanded
+        ? Row(
+            children: [
+              IconButton(
+                  icon: Icon(Icons.snippet_folder_rounded),
+                  onPressed: () =>
+                      moveLoadoutToFolder(context, widget.loadout)),
+              IconButton(
+                icon: Icon(Icons.delete),
+                onPressed: () => deleteLoadout(context, widget.loadout),
+              ),
+              IconButton(
+                icon: Icon(Icons.file_copy),
+                onPressed: () => copyLoadout(context, widget.loadout),
+              ),
+              IconButton(
+                  onPressed: _toggleControls, icon: Icon(Icons.close_fullscreen)
+              )
+            ],
+          )
+        : IconButton(
+            onPressed: _toggleControls, icon: Icon(Icons.more_vert)
+    );
+  }
+
+  void _toggleControls() {
+    setState(() {
+      _isExpanded = !_isExpanded;
+    });
   }
 
   Future<void> copyLoadout(
@@ -198,7 +234,8 @@ class ShipFittingCard extends StatelessWidget {
           content: SingleChildScrollView(
             child: ListBody(
               children: <Widget>[
-                Text('Select the target folder or press "No Folder" to move it out of the current folder'),
+                Text(
+                    'Select the target folder or press "No Folder" to move it out of the current folder'),
                 DropdownButton<String>(
                     isExpanded: true,
                     items: fittingRepo

--- a/lib/pages/ship_fitting/bloc/ship_fitting_bloc/bloc.dart
+++ b/lib/pages/ship_fitting/bloc/ship_fitting_bloc/bloc.dart
@@ -33,11 +33,11 @@ class ShipFittingBloc extends Bloc<ShipFittingEvent, ShipFittingState> {
   ) async {
     emit(UpdatingShipFitting(fitting));
     if (event is ShowFittingsMenu) {
-      mapShowFittingMenuEvent(event, emit);
+      await mapShowFittingMenuEvent(event, emit);
     }
 
     if (event is ShowRigIntegrationMenu) {
-      mapShowRigIntegrationMenu(event, emit);
+      await mapShowRigIntegrationMenu(event, emit);
     }
 
     if (event is ChangePilotForFitting) {

--- a/lib/pages/ship_fitting/bloc/ship_fitting_bloc/bloc.dart
+++ b/lib/pages/ship_fitting/bloc/ship_fitting_bloc/bloc.dart
@@ -121,9 +121,34 @@ class ShipFittingBloc extends Bloc<ShipFittingEvent, ShipFittingState> {
       // We fall through here, and deal with any exclusions
       // which at present are only on Midslots
       case SlotType.high:
+        if (fitting.ship.marketGroupId == MarketGroupFilters.pos.marketGroupId) {
+          group = _itemRepository
+              .marketGroupMap[MarketGroupFilters.structureWeapons.marketGroupId]!;
+          initialItems  = group.items ?? [];
+          break;
+        } else { // This is not very nice
+          continue normalModules;
+        }
       case SlotType.mid:
+        if (fitting.ship.marketGroupId == MarketGroupFilters.pos.marketGroupId) {
+          group = _itemRepository
+              .marketGroupMap[MarketGroupFilters.structureModules.marketGroupId]!;
+          initialItems  = group.items ?? [];
+          break;
+        } else {
+          continue normalModules;
+        }
       case SlotType.low:
+        if (fitting.ship.marketGroupId == MarketGroupFilters.pos.marketGroupId) {
+          group = _itemRepository
+              .marketGroupMap[MarketGroupFilters.structureServices.marketGroupId]!;
+          initialItems  = group.items ?? [];
+          break;
+        } else {
+          continue normalModules;
+        }
       case SlotType.combatRig:
+      normalModules:
       case SlotType.engineeringRig:
         {
           group = _itemRepository.marketGroupMap[filter.marketGroupId]!;
@@ -146,6 +171,12 @@ class ShipFittingBloc extends Bloc<ShipFittingEvent, ShipFittingState> {
           }
           break;
         }
+    }
+
+    if (group == MarketGroup.invalid && initialItems.isEmpty) {
+      // No items found to show (e.g. no Nanocores found)
+      //ToDo: This handle this exception with a pop up or something similar
+      return;
     }
 
     emit(OpenContextDrawerState(

--- a/lib/pages/ship_fitting/bloc/ship_fitting_bloc/bloc.dart
+++ b/lib/pages/ship_fitting/bloc/ship_fitting_bloc/bloc.dart
@@ -173,11 +173,7 @@ class ShipFittingBloc extends Bloc<ShipFittingEvent, ShipFittingState> {
         }
     }
 
-    if (group == MarketGroup.invalid && initialItems.isEmpty) {
-      // No items found to show (e.g. no Nanocores found)
-      //ToDo: This handle this exception with a pop up or something similar
-      return;
-    }
+    //ToDo: This handle the exception when trying to open the nanocore list for a ship that does not have any
 
     emit(OpenContextDrawerState(
       group,

--- a/lib/pages/ship_fitting/widgets/module_tiles/fitting_module_tile.dart
+++ b/lib/pages/ship_fitting/widgets/module_tiles/fitting_module_tile.dart
@@ -20,12 +20,14 @@ import 'fitting_module_tile_details.dart';
 import 'fitting_nanocore_tile_details.dart';
 
 typedef FittingModuleTileTapCallback = void Function(int index);
+typedef ModuleCloneCallback = void Function(int index);
 
 class FittingModuleTile extends StatelessWidget with FittingItemDetailsMixin {
   final int index;
   final FittingModule module;
   final FittingModuleTileTapCallback onTap;
   final VoidCallback onClearPressed;
+  final ModuleCloneCallback onClonePressed;
   final ModuleStateToggleCallback onStateToggle;
 
   const FittingModuleTile({
@@ -34,6 +36,7 @@ class FittingModuleTile extends StatelessWidget with FittingItemDetailsMixin {
     required this.module,
     required this.onTap,
     required this.onClearPressed,
+    required this.onClonePressed,
     required this.onStateToggle,
   }) : super(key: key);
 
@@ -100,6 +103,12 @@ class FittingModuleTile extends StatelessWidget with FittingItemDetailsMixin {
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             Spacer(),
+            IconButton(
+              padding: const EdgeInsets.symmetric(horizontal: 8.0),
+              constraints: BoxConstraints.tight(Size.square(32)),
+              icon: Icon(Icons.copy),
+              onPressed: () => onClonePressed(index),
+            ),
             IconButton(
               padding: const EdgeInsets.symmetric(horizontal: 8.0),
               constraints: BoxConstraints.tight(Size.square(32)),

--- a/lib/pages/ship_fitting/widgets/module_tiles/fitting_rig_integrator_tile_details.dart
+++ b/lib/pages/ship_fitting/widgets/module_tiles/fitting_rig_integrator_tile_details.dart
@@ -64,6 +64,10 @@ class FittingRigIntegratorTileDetails extends StatelessWidget {
                       index: integrator.index,
                     );
                   },
+                  onClonePressed: (int index) {
+                    // We don't want to allow cloning of items, as only one rig
+                    // of a kind is allowed in a integrated rig
+                  },
                   onStateToggle: (_) {},
                 ),
               ),

--- a/lib/pages/ship_fitting/widgets/ship_fitting_slot_tile.dart
+++ b/lib/pages/ship_fitting/widgets/ship_fitting_slot_tile.dart
@@ -155,6 +155,12 @@ class ShipFittingSlotTile extends StatelessWidget {
                     slot: slotType,
                     index: index,
                   ),
+                  onClonePressed: (int index) =>
+                      Provider.of<FittingSimulator>(context, listen: false)
+                          .cloneFittedItem(
+                    slot: slotType,
+                    index: index,
+                  ),
                 ),
               ),
             );

--- a/lib/repository/character_repository.dart
+++ b/lib/repository/character_repository.dart
@@ -86,6 +86,33 @@ class CharacterRepository {
     );
   }
 
+  Character createAutoSkillCharacter({
+    required Iterable<FittingSkill> skills,
+    required String name,
+    int baseLvl = 0,
+    int advLvl = 0,
+    int expLvl = 0}) {
+    Character char = Character(
+      name: name,
+      learntSkills: skills
+          .map(
+            (s) {
+              int level = 0;
+              if (s.levelType == SkillLevelType.basic) {
+                level = baseLvl;
+              } else if (s.levelType == SkillLevelType.advanced) {
+                level = advLvl;
+              } else if (s.levelType == SkillLevelType.expert) {
+                level = expLvl;
+              }
+              return LearnedSkill(skillId: s.itemId, skillLevel: level);
+            },
+      )
+          .toList(),
+    );
+    return char;
+  }
+
   Future<bool> moveCharacter(
       {required Character character, required int newIndex}) async {
     var index = _characters.indexWhere((e) => e.id == character.id);

--- a/lib/repository/ship_fitting_repository.dart
+++ b/lib/repository/ship_fitting_repository.dart
@@ -78,16 +78,13 @@ class ShipFittingLoadoutRepository {
     //Check if the loadout is in the root list (= not inside any folder)
     FittingListElement? target = _loadouts.firstWhereOrNull((c) => c.getId() == id);
     if (target != null) {
-      print("Object found a root");
       return target;
     }
     //Search recursively in all folders for the element
     ShipFittingFolder? folder = _loadouts.whereType<ShipFittingFolder>().firstWhereOrNull((f) => f.hasElement(id));
     if (folder != null) {
-      print("Folder found");
       return folder.getElement(id);
     }
-    print("Object not found anywhere");
     return null;
   }
 
@@ -110,11 +107,10 @@ class ShipFittingLoadoutRepository {
     }
   }
 
-  moveToFolder({required FittingListElement loadout, required String folderName}) async {
+  moveToFolder({required FittingListElement loadout, required String folderId}) async {
     ShipFittingFolder? folder;
-    folderName = folderName.trim().toLowerCase();
 
-    if (folderName == "") {
+    if (folderId == "") {
       //Move item out of current folder into root list
       deleteLoadoutSync(loadout.getId());
       _loadouts.add(loadout);
@@ -124,13 +120,13 @@ class ShipFittingLoadoutRepository {
 
     for (final el in _loadouts) {
       if (el is! ShipFittingFolder) continue;
-      if (el.name.toLowerCase() == folderName) {
+      if (el.id == folderId) {
         folder = el;
         break;
       }
     }
     if (folder == null) {
-      print('Folder with name "$folderName" not found, can\'t move item ${loadout.getName()}');
+      print('Folder with id "$folderId" not found, can\'t move item ${loadout.getName()}');
       return;
     }
 

--- a/lib/repository/ship_fitting_repository.dart
+++ b/lib/repository/ship_fitting_repository.dart
@@ -94,16 +94,29 @@ class ShipFittingLoadoutRepository {
   Future<void> moveFitting({
     required FittingListElement element,
     required int newIndex,
+    ShipFittingFolder? folder
   }) async {
-    var index = _loadouts.indexWhere((e) => e.getId() == element.getId());
+    if (folder == null) {
+      var index = _loadouts.indexWhere((e) => e.getId() == element.getId());
 
-    if (index >= 0) {
-      print('Moving ${element.getName()} to $newIndex');
+      if (index >= 0) {
+        print('Moving ${element.getName()} to $newIndex');
 
-      _loadouts.removeAt(index);
-      _loadouts.insert(newIndex, element);
+        _loadouts.removeAt(index);
+        _loadouts.insert(newIndex, element);
 
-      await saveLoadouts();
+        await saveLoadouts();
+      }
+    } else {
+      var index = folder.contents.indexWhere((e) => e.getId() == element.getId());
+      if (index >= 0) {
+        print('Moving ${element.getName()} to $newIndex inside folder ${folder.name}');
+
+        folder.contents.removeAt(index);
+        folder.contents.insert(newIndex, element);
+
+        await saveLoadouts();
+      }
     }
   }
 

--- a/lib/service/capacitor_simulator.dart
+++ b/lib/service/capacitor_simulator.dart
@@ -58,6 +58,11 @@ class CapacitorSimulator {
         item: module,
         attribute: EveEchoesAttribute.moduleReactivationDelay,
       );
+      if (duration + reactivationDelay == 0) {
+        // Some items like the gravity well traps have no 
+        // cycle time/reactivation delay
+        continue;
+      }
 
       var avgCapNeed = 0.0;
       var capNeed = 0.0;

--- a/lib/service/fitting_simulator.dart
+++ b/lib/service/fitting_simulator.dart
@@ -783,6 +783,25 @@ class FittingSimulator extends ChangeNotifier {
     return true;
   }
 
+  bool cloneFittedItem({
+        required SlotType slot,
+        required int index,
+        bool notify = true,
+        ModuleState state = ModuleState.active,
+      }) {
+    int? emptySlot;
+    for (int i = 0; i < _fitting[slot]!.length; i++) {
+      if (_fitting[slot]![i] == FittingModule.empty) {
+        emptySlot = i;
+        break;
+      }
+    }
+    if (emptySlot == null) return false;
+    FittingModule module = _fitting[slot]![index];
+    if (module == FittingModule.empty) return false;
+    return fitItem(module, slot: slot, index: emptySlot, notify: notify, state: state);
+  }
+
   void fitItemIntoAll(
     FittingModule module, {
     required SlotType slot,

--- a/lib/util/localisation_constants.dart
+++ b/lib/util/localisation_constants.dart
@@ -86,6 +86,9 @@ abstract class StaticLocalisationStrings {
   static const defaultPilot = 'Default Pilot';
   static const deleteClone = 'Delete Clone';
   static const deleteFitting = 'Delete Fitting';
+  static const moveToFolder = 'Move to Folder';
+  static const renameFolder = 'Rename Folder';
+  static const deleteFolder = 'Delete Folder';
   static const delete = 'Delete';
   static const discard = 'Discard';
   static const done = 'Done';


### PR DESCRIPTION
### New features
- Fitting List Folders
- Player outposts and modules
- "Duplicate fitted item"-button
- Intial skill levels selector for character creation
- Collapsed fitting list buttons

### Bug Fixes
- Fixed division by zero error inside the `cap_simulator`. There are items that have no runtime and reactivation delay (for example the gravity well traps, not sure if any normal items exist with no runtime)
- Add missing awaits (as suggested by @SilkyPants) to the `mapShowFittingMenuEvent` and `mapShowRigIntegrationMenu` calls inside the `ShipFittingBloc`

### Details
#### Folders
Folders allow grouping of items, currently it is only possible to have one level of folders, but this can be adjusted in the future. Fittings can be moved into a folder with a new button by selecting the folder from a dropdown. Items inside a folder can be rearanged and folders can be opened and closed.

<p float="left">
  <img src="https://github.com/sweet-org/sweet/assets/43181741/a695baab-f3ef-4291-8d42-2d1ad279bd9f" width="40%" />
  <img src="https://github.com/sweet-org/sweet/assets/43181741/dddfe6cb-2813-47fc-a286-cc03c46a88a7" width="40%" /> 
</p>

#### Structures
Added the "Personal Citadel Components" market group to the ship drawer when creating a new fitting. Also added the structure modules so they can be fitted into the outposts. However, it is not possible to fit structure modules to ships or vice versa.

#### Intial Skill Selector
When creating new characters, the initial skill level can be selected. However there is no real check whether the pre-skill requirements are fullfilled. There is only a global check whether the entered skill level is possible (e.g. "3/4/2" is not allowed). This should be not a problem, but it would be possible to achive impossible skill configuration should there be skills that do not follow this pattern.
<p float="left">
  <img src="https://github.com/sweet-org/sweet/assets/43181741/1b31f7a6-b6d8-428e-872c-571e2339bca4" width="40%" />
  <img src="https://github.com/sweet-org/sweet/assets/43181741/41c22e29-7d66-4c95-ab3d-a1b4a5f4c49e" width="40%" /> 
</p>

#### Duplicate Fitted Item Button
Inside the fitting screen, there is a new button to duplicate a fitted item. If pressed, the item will be cloned and fitted if possible. There must be a free slot and the cloned item may not violate any fitting rules (e.g. it is not possible to use this button to fit two DCUs or two active MWDs). It is possible to deep-clone integrated rigs using this button.
![New Duplicate Button](https://github.com/sweet-org/sweet/assets/43181741/22f371e1-1ebc-416d-a480-db252a3a4585)

#### Fitting list buttons
By default, the buttons for a fitting list item are collapsed and can be opened by pressing the three dots. This should improve the list display on narrow devices where the text gets scaled down/cut off if it is to long to fit.
![Fitting List Buttons](https://github.com/sweet-org/sweet/assets/43181741/edb96ad1-c30b-4853-b017-b28ccb7bd216)
